### PR TITLE
Added generic dev server 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 .DS_Store
 node_modules
+node_modules2
 
 .js
 typings
@@ -11,5 +12,6 @@ typings
 package
 
 src/custom-webpack/**/schema.json
+src/generic/**/schema.json
 *.js
 *.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .idea
 .DS_Store
 node_modules
-node_modules2
 
 .js
 typings

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ In this example `loaders` entry from Angular CLI webpack config will be _replace
 
 ## generic-dev-server
 
-Extended `@angular-devkit/build-angular:dev-server` builder that leverages the custom-webpack-browser builder above to merge configuration. Unlike the others you do not specify a webpack config or merge strategy directly with the dev-server. Instead it leverages those options from
-the targeted custom-webpack-browser.
+Enhanced `@angular-devkit/build-angular:dev-server` builder that leverages the custom webpack builder to get webpack configuration. Unlike the default `@angular-devkit/build-angular:dev-server` it doesn't use  `@angular-devkit/build-angular:browser` configuration to run the dev server. Instead it uses a builder that is specified in `browserTarget` _as long as it provides `buildWebpackConfig` method_.  
+Thus, if you use `generic-dev-server` along with `custom-webpack-browser`, `ng serve` will run with custom configuration provided in the latter.
 
 `angular.json` Example
 ```

--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@ A set of additional builders for angular-cli
 
 # Prerequisites:
  - [Angular CLI 6](https://www.npmjs.com/package/@angular/cli)
- - [@angular-devkit/architect](https://www.npmjs.com/package/@angular-devkit/architect) >= 0.7.0-rc.0
- - [@angular-devkit/build-angular](https://npmjs.com/package/@angular-devkit/build-angular) >= 0.7.0-rc.0
+ - [@angular-devkit/architect](https://www.npmjs.com/package/@angular-devkit/architect) >= 0.7.0-rc.3
+ - [@angular-devkit/build-angular](https://npmjs.com/package/@angular-devkit/build-angular) >= 0.7.0-rc.3
+ - [@angular-devkit/core](https://npmjs.com/package/@angular-devkit/core) >= 0.7.0-rc.3
+
 
 # Usage
 
  1. ```npm i -D angular-cli-builders```
- 2. In your `angular.json`:  
+ 2. In your `angular.json`:
      ```
      ...
      "architect": {
@@ -24,9 +26,9 @@ A set of additional builders for angular-cli
     - [architect-target] is the name of build target you want to run (build, serve, test etc.)
     - [name-of-builder] one of the supported builders (specified below)
  3. `ng [architect-target]`
- 
+
  ## For example
- 
+
   - angular.json:
     ```
     "architect": {
@@ -43,7 +45,7 @@ A set of additional builders for angular-cli
 
 ## custom-webpack-browser
 
-Extended `@angular-devkit/build-angular:browser` builder that allows to specify additional webpack configuration (on top of the existing under the hood).   
+Extended `@angular-devkit/build-angular:browser` builder that allows to specify additional webpack configuration (on top of the existing under the hood).
 The builder will run the same build as `@angular-devkit/build-angular:browser` does with extra parameters that are specified in the provided webpack configuration.
 
 Options:
@@ -55,7 +57,7 @@ Options:
       - `replace`: replaces the configuration entirely. The custom webpack config will replace the Angular CLI webpack config
       See [webpack-merge](https://github.com/survivejs/webpack-merge) for more info
 
-`angular.json` Example: 
+`angular.json` Example:
 ```
 "architect": {
     ...
@@ -71,12 +73,12 @@ Options:
                      "tsConfig": "src/tsconfig.app.json"
               }
 ```
-In this example `plugins` entry from `extra-webpack.config.js` will be prepended to `plugins` entry from Angular CLI underlying webpack config. 
+In this example `plugins` entry from `extra-webpack.config.js` will be prepended to `plugins` entry from Angular CLI underlying webpack config.
 
 ## custom-webpack-server
 
-Extended `@angular-devkit/build-angular:server` builder that allows to specify additional webpack configuration (on top of the existing under the hood).   
-The builder will run the same build as `@angular-devkit/build-angular:server` does with extra parameters that are specified in the provided webpack 
+Extended `@angular-devkit/build-angular:server` builder that allows to specify additional webpack configuration (on top of the existing under the hood).
+The builder will run the same build as `@angular-devkit/build-angular:server` does with extra parameters that are specified in the provided webpack
 configuration.
 
 Options:
@@ -88,7 +90,7 @@ Options:
       - `replace`: replaces the configuration entirely. The custom webpack config will replace the Angular CLI webpack config
       See [webpack-merge](https://github.com/survivejs/webpack-merge) for more info
 
-`angular.json` Example: 
+`angular.json` Example:
 ```
 "architect": {
     ...
@@ -104,3 +106,29 @@ Options:
 ```
 
 In this example `loaders` entry from Angular CLI webpack config will be _replaced_ with loaders entry from `extra-webpack.config.js`
+
+## generic-dev-server
+
+Extended `@angular-devkit/build-angular:dev-server` builder that leverages the custom-webpack-browser builder above to merge configuration. Unlike the others you do not specify a webpack config or merge strategy directly with the dev-server. Instead it leverages those options from
+the targeted custom-webpack-browser.
+
+`angular.json` Example
+```
+"architect": {
+    ...
+    "build": {
+        "builder": "angular-cli-builders:custom-webpack-browser"
+        "options": {
+            "webpackConfigPath": "./extra-webpack.config.js",
+            "mergeStrategy": { "loaders": "replace" },
+            ...
+        },
+    "serve": {
+        "builder": "angular-cli-builders:generic-dev-server",
+        "options": {
+            "browserTarget": "my-project:build"
+        }
+    }
+```
+
+In this example the dev-server will use the webpack builder from the custom-webpack-browser when invoking the serve target.

--- a/builders.json
+++ b/builders.json
@@ -13,7 +13,7 @@
     },
     "generic-dev-server": {
       "class": "./src/generic/dev-server",
-      "schema": "./src/generic/dev-server/schema.json",
+      "schema": "@angular-devkit/build-angular/src/dev-server/schema.json",
       "description": "Dev Server extended to build with targeted builder"
     }
   }

--- a/builders.json
+++ b/builders.json
@@ -10,6 +10,11 @@
       "class": "./src/custom-webpack/server",
       "schema": "./src/custom-webpack/server/schema.json",
       "description": "Build server app extended with custom webpack config"
+    },
+    "generic-dev-server": {
+      "class": "./src/generic/dev-server",
+      "schema": "./src/generic/dev-server/schema.json",
+      "description": "Dev Server extended to build with targeted builder"
     }
   }
 }

--- a/builders.json
+++ b/builders.json
@@ -13,7 +13,7 @@
     },
     "generic-dev-server": {
       "class": "./src/generic/dev-server",
-      "schema": "@angular-devkit/build-angular/src/dev-server/schema.json",
+      "schema": "./src/generic/dev-server/schema.json",
       "description": "Dev Server extended to build with targeted builder"
     }
   }

--- a/e2e/generic-dev-server-schema.spec.ts
+++ b/e2e/generic-dev-server-schema.spec.ts
@@ -1,0 +1,13 @@
+describe('generic dev server builder test', () => {
+	let genericDevServerSchema: any;
+
+	beforeEach(() => {
+		jest.resetModules()
+		genericDevServerSchema = require('../src/generic/dev-server/schema.json');
+	});
+
+	it('Should fit the schema of @angular-devkit/build-angular:dev-server', () => {
+		const originalDevServerSchema = require('@angular-devkit/build-angular/src/dev-server/schema.json');
+		expect(genericDevServerSchema.properties).toEqual(originalDevServerSchema.properties);
+	});
+});

--- a/index.ts
+++ b/index.ts
@@ -3,3 +3,4 @@
  */
 export * from './src/custom-webpack/browser/index';
 export * from './src/custom-webpack/server/index';
+export * from './src/generic/dev-server/index';

--- a/merge-schemes.ts
+++ b/merge-schemes.ts
@@ -17,6 +17,11 @@ const schemesToMerge: CustomSchema[] = [
 		originalSchemaPath: '@angular-devkit/build-angular/src/server/schema.json',
 		schemaExtensionPaths: ['./src/custom-webpack/server/schema.ext.json', './src/custom-webpack/schema.ext.json'],
 		newSchemaPath: './src/custom-webpack/server/schema.json'
+	},
+	{
+		originalSchemaPath: '@angular-devkit/build-angular/src/dev-server/schema.json',
+		schemaExtensionPaths: ['./src/generic/dev-server/schema.ext.json'],
+		newSchemaPath: './src/generic/dev-server/schema.json'
 	}
 ];
 

--- a/merge-schemes.ts
+++ b/merge-schemes.ts
@@ -20,7 +20,7 @@ const schemesToMerge: CustomSchema[] = [
 	},
 	{
 		originalSchemaPath: '@angular-devkit/build-angular/src/dev-server/schema.json',
-		schemaExtensionPath: './src/generic/dev-server/schema.ext.json',
+		schemaExtensionPaths: ['./src/generic/dev-server/schema.ext.json'],
 		newSchemaPath: './src/generic/dev-server/schema.json'
 	}
 ];

--- a/merge-schemes.ts
+++ b/merge-schemes.ts
@@ -17,6 +17,11 @@ const schemesToMerge: CustomSchema[] = [
 		originalSchemaPath: '@angular-devkit/build-angular/src/server/schema.json',
 		schemaExtensionPath: './src/custom-webpack/server/schema.ext.json',
 		newSchemaPath: './src/custom-webpack/server/schema.json'
+	},
+	{
+		originalSchemaPath: '@angular-devkit/build-angular/src/dev-server/schema.json',
+		schemaExtensionPath: './src/generic/dev-server/schema.ext.json',
+		newSchemaPath: './src/generic/dev-server/schema.json'
 	}
 ];
 

--- a/merge-schemes.ts
+++ b/merge-schemes.ts
@@ -17,11 +17,6 @@ const schemesToMerge: CustomSchema[] = [
 		originalSchemaPath: '@angular-devkit/build-angular/src/server/schema.json',
 		schemaExtensionPaths: ['./src/custom-webpack/server/schema.ext.json', './src/custom-webpack/schema.ext.json'],
 		newSchemaPath: './src/custom-webpack/server/schema.json'
-	},
-	{
-		originalSchemaPath: '@angular-devkit/build-angular/src/dev-server/schema.json',
-		schemaExtensionPaths: ['./src/generic/dev-server/schema.ext.json'],
-		newSchemaPath: './src/generic/dev-server/schema.json'
 	}
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,32 +1,32 @@
 {
   "name": "angular-cli-builders",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@angular-devkit/architect": {
-      "version": "0.7.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.7.0-rc.0.tgz",
-      "integrity": "sha512-GsI3MoW7yLu1j7FZSeM0bNw8E4PaehuLqecx7vmBjkbasrgpjRUwO71UgDPb9DZdhZQL14rtjUnuNTwhK+d6ug==",
+      "version": "0.7.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.7.0-rc.3.tgz",
+      "integrity": "sha512-Ex/xUjUONwi4j9Fxk7/ukbNuYHx65Gd7LeDjNK/JlkBkKFRyE3O0iBTBZGQlHdlfzy/ccu5IvlLa1iAKwHMmLw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "0.7.0-rc.0",
-        "rxjs": "6.2.1"
+        "@angular-devkit/core": "0.7.0-rc.3",
+        "rxjs": "6.2.2"
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "0.7.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.7.0-rc.0.tgz",
-      "integrity": "sha512-xT3Mvv/xF7CQDZvO4RhcQ1gcfDzSMGMRYq/gvcr1fkcTdRaYmvNrrJ3KtFK7+0BAPuQx4lhZW3G+nv9KrZrkDw==",
+      "version": "0.7.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-0.7.0-rc.3.tgz",
+      "integrity": "sha512-QS590JAHdaHkEGGTKMMnq+zwhVdWV6qbGgCw2/B0Ad6e8qlUMJziravgzWo4ymySFzXPSCuKAeZC1YZKWtUTYw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.7.0-rc.0",
-        "@angular-devkit/build-optimizer": "0.7.0-rc.0",
-        "@angular-devkit/build-webpack": "0.7.0-rc.0",
-        "@angular-devkit/core": "0.7.0-rc.0",
-        "@ngtools/webpack": "6.1.0-rc.0",
+        "@angular-devkit/architect": "0.7.0-rc.3",
+        "@angular-devkit/build-optimizer": "0.7.0-rc.3",
+        "@angular-devkit/build-webpack": "0.7.0-rc.3",
+        "@angular-devkit/core": "0.7.0-rc.3",
+        "@ngtools/webpack": "6.1.0-rc.3",
         "ajv": "6.4.0",
-        "autoprefixer": "8.6.4",
+        "autoprefixer": "8.6.5",
         "circular-dependency-plugin": "5.0.2",
         "clean-css": "4.1.11",
         "copy-webpack-plugin": "4.5.2",
@@ -36,22 +36,22 @@
         "istanbul": "0.4.5",
         "istanbul-instrumenter-loader": "3.0.1",
         "karma-source-map-support": "1.3.0",
-        "less": "3.0.4",
+        "less": "3.8.0",
         "less-loader": "4.1.0",
         "license-webpack-plugin": "1.3.1",
         "mini-css-extract-plugin": "0.4.1",
         "minimatch": "3.0.4",
-        "node-sass": "4.9.0",
+        "node-sass": "4.9.2",
         "opn": "5.3.0",
         "parse5": "4.0.0",
         "portfinder": "1.0.13",
         "postcss": "6.0.23",
         "postcss-import": "11.1.0",
-        "postcss-loader": "2.1.5",
+        "postcss-loader": "2.1.6",
         "postcss-url": "7.3.2",
         "raw-loader": "0.5.1",
-        "rxjs": "6.2.1",
-        "sass-loader": "7.0.3",
+        "rxjs": "6.2.2",
+        "sass-loader": "6.0.7",
         "source-map-loader": "0.2.3",
         "source-map-support": "0.5.6",
         "stats-webpack-plugin": "0.6.2",
@@ -63,16 +63,16 @@
         "url-loader": "1.0.1",
         "webpack": "4.9.2",
         "webpack-dev-middleware": "3.1.3",
-        "webpack-dev-server": "3.1.4",
+        "webpack-dev-server": "3.1.5",
         "webpack-merge": "4.1.3",
         "webpack-sources": "1.1.0",
         "webpack-subresource-integrity": "1.1.0-rc.4"
       }
     },
     "@angular-devkit/build-optimizer": {
-      "version": "0.7.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.7.0-rc.0.tgz",
-      "integrity": "sha512-R7nZIp1rXB1L90F8u3FZOYaMIDxSp+yDZ4cbD8ivevdNuTEL2JFG3y8LfnjVI96RVqEumKzHXonIgAy6Mtv1GA==",
+      "version": "0.7.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.7.0-rc.3.tgz",
+      "integrity": "sha512-UE3LW/SFhdRf65cT2nF0wadunxAfWzFr4u2K+pQ+517ebE/FlwWunbOKO6FsydFFpJeWacgGkF1zIJHoqgczCg==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
@@ -82,25 +82,25 @@
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.7.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.7.0-rc.0.tgz",
-      "integrity": "sha512-R2zqCfv4FVcCAIxSMNJqSS+XjTZ8q52Kqcr+orAf0xV8mdsCEuVgm4vm5yHVVt3K+KG8g6hsdzDDXgKnb/epQQ==",
+      "version": "0.7.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.7.0-rc.3.tgz",
+      "integrity": "sha512-bXQZRapkMvy1ovON4VeGDeYohl3UbVcGPEU85Lmv8x0/EopTR7zMs7SaxJqjMfRmcOJQBkDm8OLNATrIWD0bHw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.7.0-rc.0",
-        "@angular-devkit/core": "0.7.0-rc.0",
-        "rxjs": "6.2.1"
+        "@angular-devkit/architect": "0.7.0-rc.3",
+        "@angular-devkit/core": "0.7.0-rc.3",
+        "rxjs": "6.2.2"
       }
     },
     "@angular-devkit/core": {
-      "version": "0.7.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.7.0-rc.0.tgz",
-      "integrity": "sha512-hE15jDi/vSGt3cZNf8Z2DZVtd6AUr/tGOenpHckFKZ4s8l1TsKcscZqNwCCalIazFP8c8xYYesdBHC7+WXwO3g==",
+      "version": "0.7.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.7.0-rc.3.tgz",
+      "integrity": "sha512-Mu3eLGRq7yDxlYt82uBPXvEt8CtXolGqZFkVsTyR3Ksuf+hJUjy/xMfkXGUk//9TY/U1kZ43DrZdz2ciLXDkBA==",
       "dev": true,
       "requires": {
         "ajv": "6.4.0",
         "chokidar": "2.0.4",
-        "rxjs": "6.2.1",
+        "rxjs": "6.2.2",
         "source-map": "0.5.7"
       }
     },
@@ -125,12 +125,13 @@
       }
     },
     "@ngtools/webpack": {
-      "version": "6.1.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-6.1.0-rc.0.tgz",
-      "integrity": "sha512-gSVs6D6ozFGAkLfZ0vxm+9q49Xz4BxShsTOVjZqzy1ma+Kw0x5yiURumVEnG/gfKQAWdIqTdBMsdVA3AwJNnqg==",
+      "version": "6.1.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-6.1.0-rc.3.tgz",
+      "integrity": "sha512-DfMWEjr2v/cvlOSC6qMlRcbRj90QxF/AcAsjOiQSnPuuAybGDY8N8psGTpBV43SlIzNSZZDlKvrODiT8pLV+Bw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "0.7.0-rc.0",
+        "@angular-devkit/core": "0.7.0-rc.3",
+        "rxjs": "6.2.2",
         "tree-kill": "1.2.0",
         "webpack-sources": "1.1.0"
       }
@@ -757,13 +758,13 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "8.6.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.4.tgz",
-      "integrity": "sha512-9D0OoxWCqq9Okp9wD+igaCf6ZaNjYNFSCKxgMLAxAGqXwpapaZ+D0PBv265VHQLgam8a7gld4E6KgJJM6SKfQQ==",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.5.tgz",
+      "integrity": "sha512-PLWJN3Xo/rycNkx+mp8iBDMTm3FeWe4VmYaZDSqL5QQB9sLsQkG5k8n+LNDFnhh9kdq2K+egL/icpctOmDHwig==",
       "dev": true,
       "requires": {
         "browserslist": "3.2.8",
-        "caniuse-lite": "1.0.30000861",
+        "caniuse-lite": "1.0.30000865",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.23",
@@ -1263,19 +1264,20 @@
       "dev": true,
       "requires": {
         "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.1",
+        "browserify-des": "1.0.2",
         "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
-      "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
         "cipher-base": "1.0.4",
         "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-rsa": {
@@ -1318,8 +1320,8 @@
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000861",
-        "electron-to-chromium": "1.3.50"
+        "caniuse-lite": "1.0.30000865",
+        "electron-to-chromium": "1.3.52"
       }
     },
     "bser": {
@@ -1458,9 +1460,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000861",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000861.tgz",
-      "integrity": "sha512-aeEQ4kyd41qCl8XFbCjWgVBI3EOd66M9sC43MFn0kuD/vcrNqvoIAlKon4xdp8yMCYvVjdCltI3lgArj8I6cNA==",
+      "version": "1.0.30000865",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz",
+      "integrity": "sha512-vs79o1mOSKRGv/1pSkp4EXgl4ZviWeYReXw60XfacPU64uQWZwJT6vZNmxRF9O+6zu71sJwMxLK5JXxbzuVrLw==",
       "dev": true
     },
     "capture-exit": {
@@ -1679,9 +1681,9 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
       "dev": true
     },
     "commondir": {
@@ -1708,21 +1710,21 @@
       "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
       "dev": true,
       "requires": {
-        "mime-db": "1.34.0"
+        "mime-db": "1.35.0"
       },
       "dependencies": {
         "mime-db": {
-          "version": "1.34.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.34.0.tgz",
-          "integrity": "sha1-RS0Oz/XDA0am3B5kseruDTcZ/5o=",
+          "version": "1.35.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
           "dev": true
         }
       }
     },
     "compression": {
-      "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
-      "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+      "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
       "dev": true,
       "requires": {
         "accepts": "1.3.5",
@@ -1730,16 +1732,8 @@
         "compressible": "2.0.14",
         "debug": "2.6.9",
         "on-headers": "1.0.1",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "vary": "1.1.2"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
-        }
       }
     },
     "concat-map": {
@@ -1866,25 +1860,26 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-      "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+      "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
       "dev": true,
       "requires": {
         "is-directory": "0.3.1",
         "js-yaml": "3.12.0",
-        "minimist": "1.2.0",
-        "object-assign": "4.1.1",
-        "os-homedir": "1.0.2",
-        "parse-json": "2.2.0",
-        "require-from-string": "1.2.1"
+        "parse-json": "4.0.0",
+        "require-from-string": "2.0.2"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.2",
+            "json-parse-better-errors": "1.0.2"
+          }
         }
       }
     },
@@ -2087,6 +2082,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
+      "optional": true,
       "requires": {
         "boom": "2.10.1"
       }
@@ -2566,9 +2562,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.50",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.50.tgz",
-      "integrity": "sha1-dDi3b5K0G5GfP73TUPvQdX2s3fc=",
+      "version": "1.3.52",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz",
+      "integrity": "sha1-0tnxJwuko7lnuDHEDvcftNmrXOA=",
       "dev": true
     },
     "elliptic": {
@@ -2579,7 +2575,7 @@
       "requires": {
         "bn.js": "4.11.8",
         "brorand": "1.1.0",
-        "hash.js": "1.1.4",
+        "hash.js": "1.1.5",
         "hmac-drbg": "1.0.1",
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.1",
@@ -2736,9 +2732,9 @@
       }
     },
     "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
       "dev": true,
       "requires": {
         "esrecurse": "4.2.1",
@@ -3261,9 +3257,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
-      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
+      "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
       "dev": true,
       "requires": {
         "debug": "3.1.0"
@@ -3951,23 +3947,6 @@
         "globule": "1.2.1"
       }
     },
-    "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true,
-      "optional": true
-    },
-    "generate-object-property": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "is-property": "1.0.2"
-      }
-    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -4284,9 +4263,9 @@
       }
     },
     "hash.js": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
-      "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -4298,6 +4277,7 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "boom": "2.10.1",
         "cryptiles": "2.0.5",
@@ -4317,7 +4297,7 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.4",
+        "hash.js": "1.1.5",
         "minimalistic-assert": "1.0.1",
         "minimalistic-crypto-utils": "1.0.1"
       }
@@ -4372,18 +4352,18 @@
       "dev": true
     },
     "html-minifier": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.17.tgz",
-      "integrity": "sha512-O+StuKL0UWfwX5Zv4rFxd60DPcT5DVjGq1AlnP6VQ8wzudft/W4hx5Wl98aSYNwFBHY6XWJreRw/BehX4l+diQ==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.19.tgz",
+      "integrity": "sha512-Qr2JC9nsjK8oCrEmuB430ZIA8YWbF3D5LSjywD75FTuXmeqacwHgIM8wp3vHYzzPbklSjp53RdmDuzR4ub2HzA==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
         "clean-css": "4.1.11",
-        "commander": "2.15.1",
+        "commander": "2.16.0",
         "he": "1.1.1",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.4.2"
+        "uglify-js": "3.4.5"
       }
     },
     "html-webpack-plugin": {
@@ -4392,7 +4372,7 @@
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
-        "html-minifier": "3.5.17",
+        "html-minifier": "3.5.19",
         "loader-utils": "0.2.17",
         "lodash": "4.17.10",
         "pretty-error": "2.1.1",
@@ -4493,7 +4473,7 @@
       "dev": true,
       "requires": {
         "eventemitter3": "3.1.0",
-        "follow-redirects": "1.5.0",
+        "follow-redirects": "1.5.1",
         "requires-port": "1.0.0"
       }
     },
@@ -4556,6 +4536,24 @@
       "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
       "dev": true,
       "optional": true
+    },
+    "import-cwd": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
+      "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
+      "dev": true,
+      "requires": {
+        "import-from": "2.1.0"
+      }
+    },
+    "import-from": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+      "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "3.0.0"
+      }
     },
     "import-local": {
       "version": "1.0.0",
@@ -4823,27 +4821,6 @@
         "is-extglob": "2.1.1"
       }
     },
-    "is-my-ip-valid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-      "dev": true,
-      "optional": true
-    },
-    "is-my-json-valid": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
-    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -4908,13 +4885,6 @@
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
-    },
-    "is-property": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true,
-      "optional": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -5779,9 +5749,9 @@
       }
     },
     "js-base64": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",
-      "integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.8.tgz",
+      "integrity": "sha512-hm2nYpDrwoO/OzBhdcqs/XGT6XjSuSSCVEpia+Kl2J6x4CYt5hISlVL/AYU1khoDXv0AQVgxtdJySb9gjAn56Q==",
       "dev": true,
       "optional": true
     },
@@ -5957,13 +5927,6 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
-    "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true,
-      "optional": true
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -6026,9 +5989,9 @@
       "dev": true
     },
     "less": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/less/-/less-3.0.4.tgz",
-      "integrity": "sha512-q3SyEnPKbk9zh4l36PGeW2fgynKu+FpbhiUNx/yaiBUQ3V0CbACCgb9FzYWcRgI2DJlP6eI4jc8XPrCTi55YcQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/less/-/less-3.8.0.tgz",
+      "integrity": "sha512-746DPDyL+Wsjo7h/Z3t+A3Mg/mpDTaxW4puZyLhCQJjWJJvHggN735orjuCLIYgo7jKqv1zWLiQrxkuUOg5oGA==",
       "dev": true,
       "requires": {
         "errno": "0.1.7",
@@ -6852,9 +6815,9 @@
       }
     },
     "node-sass": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
-      "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.2.tgz",
+      "integrity": "sha512-LdxoJLZutx0aQXHtWIYwJKMj+9pTjneTcLWJgzf2XbGu0q5pRNqW5QvFCEdm3mc5rJOdru/mzln5d0EZLacf6g==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -6873,7 +6836,7 @@
         "nan": "2.10.0",
         "node-gyp": "3.7.0",
         "npmlog": "4.1.2",
-        "request": "2.79.0",
+        "request": "2.87.0",
         "sass-graph": "2.2.4",
         "stdout-stream": "1.4.0",
         "true-case-path": "1.0.2"
@@ -6883,26 +6846,6 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true,
-          "optional": true
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
           "dev": true,
           "optional": true
         },
@@ -6911,6 +6854,7 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-styles": "2.2.1",
             "escape-string-regexp": "1.0.5",
@@ -6919,89 +6863,10 @@
             "supports-color": "2.0.0"
           }
         },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.15.1",
-            "is-my-json-valid": "2.17.2",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.2"
-          }
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true,
-          "optional": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.7.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.6",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.3.2"
-          }
-        },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true,
           "optional": true
         }
@@ -7612,46 +7477,24 @@
       }
     },
     "postcss-load-config": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
-      "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
+      "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1",
-        "postcss-load-options": "1.2.0",
-        "postcss-load-plugins": "2.3.0"
-      }
-    },
-    "postcss-load-options": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
-      "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
-      }
-    },
-    "postcss-load-plugins": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
-      "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
-      "dev": true,
-      "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "4.0.0",
+        "import-cwd": "2.1.0"
       }
     },
     "postcss-loader": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.5.tgz",
-      "integrity": "sha512-pV7kB5neJ0/1tZ8L1uGOBNTVBCSCXQoIsZMsrwvO8V2rKGa2tBl/f80GGVxow2jJnRJ2w1ocx693EKhZAb9Isg==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.1.6.tgz",
+      "integrity": "sha512-hgiWSc13xVQAq25cVw80CH0l49ZKlAnU1hKPOdRrNj89bokRr/bZF2nT+hebPPF9c9xs8c3gw3Fr2nxtmXYnNg==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
         "postcss": "6.0.23",
-        "postcss-load-config": "1.2.0",
+        "postcss-load-config": "2.0.0",
         "schema-utils": "0.4.5"
       }
     },
@@ -8190,9 +8033,9 @@
       "dev": true
     },
     "require-from-string": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "require-main-filename": {
@@ -8285,9 +8128,9 @@
       }
     },
     "rxjs": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.1.tgz",
-      "integrity": "sha512-OwMxHxmnmHTUpgO+V7dZChf3Tixf4ih95cmXjzzadULziVl/FKhHScGLj4goEw9weePVOH2Q0+GcCBUhKCZc/g==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.2.2.tgz",
+      "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
       "dev": true,
       "requires": {
         "tslib": "1.9.3"
@@ -8403,9 +8246,9 @@
       }
     },
     "sass-loader": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.0.3.tgz",
-      "integrity": "sha512-iaSFtQcGo4SSgDw5Aes5p4VTrA5jCGSA7sGmhPIcOloBlgI1VktM2MUrk2IHHjbNagckXlPz+HWq1vAAPrcYxA==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.7.tgz",
+      "integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
       "dev": true,
       "requires": {
         "clone-deep": "2.0.2",
@@ -8438,7 +8281,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "js-base64": "2.4.5",
+        "js-base64": "2.4.8",
         "source-map": "0.4.4"
       },
       "dependencies": {
@@ -8776,6 +8619,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.16.3"
       }
@@ -8791,9 +8635,9 @@
       }
     },
     "sockjs-client": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
-      "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+      "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -9154,7 +8998,8 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
       "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -9742,12 +9587,12 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.2.tgz",
-      "integrity": "sha512-/kVQDzwiE9Vy7Y63eMkMozF4jIt0C2+xHctF9YpqNWdE/NLOuMurshkpoYGUlAbeYhACPv0HJPIHJul0Ak4/uw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.5.tgz",
+      "integrity": "sha512-Fm52gLqJqFBnT+Sn411NPDnsgaWiYeRLw42x7Va/mS8TKgaepwoGY7JLXHSEef3d3PmdFXSz1Zx7KMLL89E2QA==",
       "dev": true,
       "requires": {
-        "commander": "2.15.1",
+        "commander": "2.16.0",
         "source-map": "0.6.1"
       },
       "dependencies": {
@@ -10169,7 +10014,7 @@
         "ajv-keywords": "3.2.0",
         "chrome-trace-event": "0.1.3",
         "enhanced-resolve": "4.1.0",
-        "eslint-scope": "3.7.1",
+        "eslint-scope": "3.7.3",
         "json-parse-better-errors": "1.0.2",
         "loader-runner": "2.3.0",
         "loader-utils": "1.1.0",
@@ -10236,16 +10081,16 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.4.tgz",
-      "integrity": "sha512-itcIUDFkHuj1/QQxzUFOEXXmxOj5bku2ScLEsOFPapnq2JRTm58gPdtnBphBJOKL2+M3p6+xygL64bI+3eyzzw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.5.tgz",
+      "integrity": "sha512-LVHg+EPwZLHIlfvokSTgtJqO/vI5CQi89fASb5JEDtVMDjY0yuIEqPPdMiKaBJIB/Ab7v/UN/sYZ7WsZvntQKw==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
         "array-includes": "3.0.3",
         "bonjour": "3.5.0",
         "chokidar": "2.0.4",
-        "compression": "1.7.2",
+        "compression": "1.7.3",
         "connect-history-api-fallback": "1.5.0",
         "debug": "3.1.0",
         "del": "3.0.0",
@@ -10262,7 +10107,7 @@
         "selfsigned": "1.10.3",
         "serve-index": "1.9.1",
         "sockjs": "0.3.19",
-        "sockjs-client": "1.1.4",
+        "sockjs-client": "1.1.5",
         "spdy": "3.4.7",
         "strip-ansi": "3.0.1",
         "supports-color": "5.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-cli-builders",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
   "builders": "builders.json",
   "dependencies": {},
   "devDependencies": {
-    "@angular-devkit/architect": "^0.7.0-rc.0",
-    "@angular-devkit/build-angular": "^0.7.0-rc.0",
+    "@angular-devkit/architect": "^0.7.0-rc.3",
+    "@angular-devkit/build-angular": "^0.7.0-rc.3",
+    "@angular-devkit/core": "^0.7.0-rc.3",
     "@types/jest": "^23.1.4",
     "@types/lodash": "^4.14.110",
     "@types/node": "^10.5.1",
@@ -55,7 +56,8 @@
     "typescript": "^2.9.2"
   },
   "peerDependencies": {
-    "@angular-devkit/architect": ">=0.7.0-rc.0",
-    "@angular-devkit/build-angular": ">=0.7.0-rc.0"
+    "@angular-devkit/architect": ">=0.7.0-rc.3",
+    "@angular-devkit/build-angular": ">=0.7.0-rc.3",
+    "@angular-devkit/core": "^0.7.0-rc.3"
   }
 }

--- a/src/generic/dev-server/index.ts
+++ b/src/generic/dev-server/index.ts
@@ -7,8 +7,6 @@ import {tap, switchMap} from 'rxjs/operators';
 import * as fs from 'fs';
 
 
-const webpackMerge = require('webpack-merge');
-
 export class GenericDevServerBuilder extends DevServerBuilder {
 
   private targetBuilder: Builder<BrowserBuilderSchema> | undefined;

--- a/src/generic/dev-server/index.ts
+++ b/src/generic/dev-server/index.ts
@@ -4,7 +4,8 @@ import {DevServerBuilder, DevServerBuilderOptions, BrowserBuilderSchema, Browser
 import {Path, virtualFs} from '@angular-devkit/core';
 import {Observable} from 'rxjs';
 import {tap, switchMap} from 'rxjs/operators';
-import * as fs from 'fs';
+import {Stats} from 'fs';
+import {GenericWebpackBuilder} from '../generic-webpack-builder';
 
 
 export class GenericDevServerBuilder extends DevServerBuilder {
@@ -33,18 +34,15 @@ export class GenericDevServerBuilder extends DevServerBuilder {
   buildWebpackConfig(
     root: Path,
     projectRoot: Path,
-    host: virtualFs.Host<fs.Stats>,
+    host: virtualFs.Host<Stats>,
     browserOptions: BrowserBuilderSchema,
   ) {
-    // If our target builder has a webpack config method lets use it. Otherwise we
-    // will fall to the default config
-    if (this.targetBuilder instanceof BrowserBuilder) {
-      return (<BrowserBuilder> this.targetBuilder).buildWebpackConfig(
-        root, projectRoot, host, <NormalizedBrowserBuilderSchema> browserOptions
-      );
-    }
-
-    return super.buildWebpackConfig(root, projectRoot, host, browserOptions);
+    // Check if we can use the generic webpack builder if so lets use it, otherwise we'll fall back to the DevServerBuilder's
+    // implementation
+    return (
+      GenericWebpackBuilder.buildWebpackConfig(this.targetBuilder, root, projectRoot, host, browserOptions) ||
+      super.buildWebpackConfig(root, projectRoot, host, browserOptions)
+    );
   }
 }
 

--- a/src/generic/dev-server/index.ts
+++ b/src/generic/dev-server/index.ts
@@ -1,0 +1,53 @@
+
+import {BuilderContext, BuilderConfiguration, BuildEvent, Builder} from '@angular-devkit/architect';
+import {DevServerBuilder, DevServerBuilderOptions, BrowserBuilderSchema, BrowserBuilder, NormalizedBrowserBuilderSchema } from '@angular-devkit/build-angular';
+import {Path, virtualFs} from '@angular-devkit/core';
+import {Observable} from 'rxjs';
+import {tap, switchMap} from 'rxjs/operators';
+import * as fs from 'fs';
+
+
+const webpackMerge = require('webpack-merge');
+
+export class GenericDevServerBuilder extends DevServerBuilder {
+
+  private targetBuilder: Builder<BrowserBuilderSchema> | undefined;
+
+  constructor(context: BuilderContext) {
+    super(context);
+  }
+
+  run(builderConfig: BuilderConfiguration<DevServerBuilderOptions>): Observable<BuildEvent> {
+
+    const architect = this.context.architect;
+    const [project, target, configuration] = builderConfig.options.browserTarget.split(':');
+    const targetSpec = { project, target, configuration };
+    const targetConfig = architect.getBuilderConfiguration(targetSpec);
+
+    // Before we run the dev server grab the target builder so that we have it syncroniously
+    // when we're ready to build the webpack config.
+    return architect.getBuilderDescription(targetConfig).pipe(
+      tap(targetDescription => this.targetBuilder = architect.getBuilder<BrowserBuilderSchema>(targetDescription, this.context)),
+      switchMap(() => super.run(builderConfig))
+    )
+  }
+
+  buildWebpackConfig(
+    root: Path,
+    projectRoot: Path,
+    host: virtualFs.Host<fs.Stats>,
+    browserOptions: BrowserBuilderSchema,
+  ) {
+    // If our target builder has a webpack config method lets use it. Otherwise we
+    // will fall to the default config
+    if (this.targetBuilder instanceof BrowserBuilder) {
+      return (<BrowserBuilder> this.targetBuilder).buildWebpackConfig(
+        root, projectRoot, host, <NormalizedBrowserBuilderSchema> browserOptions
+      );
+    }
+
+    return super.buildWebpackConfig(root, projectRoot, host, browserOptions);
+  }
+}
+
+export default GenericDevServerBuilder;

--- a/src/generic/dev-server/index.ts
+++ b/src/generic/dev-server/index.ts
@@ -1,16 +1,16 @@
-
-import {BuilderContext, BuilderConfiguration, BuildEvent, Builder} from '@angular-devkit/architect';
-import {DevServerBuilder, DevServerBuilderOptions, BrowserBuilderSchema, BrowserBuilder, NormalizedBrowserBuilderSchema } from '@angular-devkit/build-angular';
+import {Builder, BuilderConfiguration, BuilderContext, BuilderDescription, BuildEvent} from '@angular-devkit/architect';
+import {BrowserBuilderSchema, DevServerBuilder, DevServerBuilderOptions} from '@angular-devkit/build-angular';
 import {Path, virtualFs} from '@angular-devkit/core';
 import {Observable} from 'rxjs';
-import {tap, switchMap} from 'rxjs/operators';
+import {switchMap, tap} from 'rxjs/operators';
 import {Stats} from 'fs';
 import {GenericWebpackBuilder} from '../generic-webpack-builder';
+import {Configuration} from "webpack";
 
 
 export class GenericDevServerBuilder extends DevServerBuilder {
 
-  private targetBuilder: Builder<BrowserBuilderSchema> | undefined;
+  private targetBuilder: Builder<any> | undefined;
 
   constructor(context: BuilderContext) {
     super(context);
@@ -23,10 +23,10 @@ export class GenericDevServerBuilder extends DevServerBuilder {
     const targetSpec = { project, target, configuration };
     const targetConfig = architect.getBuilderConfiguration(targetSpec);
 
-    // Before we run the dev server grab the target builder so that we have it syncroniously
+    // Before we run the dev server grab the target builder so that we have it synchronously
     // when we're ready to build the webpack config.
     return architect.getBuilderDescription(targetConfig).pipe(
-      tap(targetDescription => this.targetBuilder = architect.getBuilder<BrowserBuilderSchema>(targetDescription, this.context)),
+      tap((targetDescription: BuilderDescription) => this.targetBuilder = architect.getBuilder<BrowserBuilderSchema>(targetDescription, this.context)),
       switchMap(() => super.run(builderConfig))
     )
   }
@@ -36,7 +36,7 @@ export class GenericDevServerBuilder extends DevServerBuilder {
     projectRoot: Path,
     host: virtualFs.Host<Stats>,
     browserOptions: BrowserBuilderSchema,
-  ) {
+  ): Configuration {
     // Check if we can use the generic webpack builder if so lets use it, otherwise we'll fall back to the DevServerBuilder's
     // implementation
     return (

--- a/src/generic/dev-server/schema.d.ts
+++ b/src/generic/dev-server/schema.d.ts
@@ -1,7 +1,3 @@
-/**
- * Created by Evgeny Barabanov on 01/07/2018.
- */
-
 import { BrowserBuilderSchema } from '@angular-devkit/build-angular';
 
 export interface GenericDevServerBuildSchema extends BrowserBuilderSchema { }

--- a/src/generic/dev-server/schema.d.ts
+++ b/src/generic/dev-server/schema.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Created by Evgeny Barabanov on 01/07/2018.
+ */
+
+import { BrowserBuilderSchema } from '@angular-devkit/build-angular';
+
+export interface GenericDevServerBuildSchema extends BrowserBuilderSchema { }

--- a/src/generic/dev-server/schema.d.ts
+++ b/src/generic/dev-server/schema.d.ts
@@ -1,3 +1,0 @@
-import { BrowserBuilderSchema } from '@angular-devkit/build-angular';
-
-export interface GenericDevServerBuildSchema extends BrowserBuilderSchema { }

--- a/src/generic/dev-server/schema.ext.json
+++ b/src/generic/dev-server/schema.ext.json
@@ -1,0 +1,5 @@
+{
+  "title": "Generic dev server schema for Build Facade",
+  "id": "GenericWebpackDevServerSchema",
+  "description": "Dev server target options"
+}

--- a/src/generic/generic-webpack-builder.spec.ts
+++ b/src/generic/generic-webpack-builder.spec.ts
@@ -1,0 +1,45 @@
+import {GenericWebpackBuilder} from './generic-webpack-builder';
+import {Path, virtualFs} from '@angular-devkit/core';
+import {Builder} from '@angular-devkit/architect';
+import {BrowserBuilderSchema } from '@angular-devkit/build-angular';
+import {Stats} from 'fs';
+
+describe('GenericWebpackBuilder test', () => {
+
+  const mockRoot = <Path> 'mockRoot';
+  const mockProjectRoot = <Path> 'mockProjectRoot';
+  const mockHost = <virtualFs.Host<Stats>> <any> 'mockHost';
+  const mockBrowserOptions = <BrowserBuilderSchema> <any> 'mockBrowserOptions';
+
+  it('should invoke the target builder when the target has the buildWebpackConfig method', () => {
+    const mockTarget = <Builder<BrowserBuilderSchema>> <any> {
+      buildWebpackConfig: () => {}
+    }
+    spyOn(mockTarget,'buildWebpackConfig').and.returnValue('mockConfig');
+
+    const result = GenericWebpackBuilder.buildWebpackConfig(mockTarget, mockRoot, mockProjectRoot, mockHost, mockBrowserOptions)
+
+    expect(result).toBe('mockConfig');
+    expect(mockTarget.buildWebpackConfig).toHaveBeenCalledWith('mockRoot','mockProjectRoot','mockHost','mockBrowserOptions');
+
+  });
+
+  it('should not invoke the target builder when the target does not have the buildWebpackConfig method', () => {
+    const mockTarget = <Builder<BrowserBuilderSchema>> <any> {
+      anyOtherMethod: () => {}
+    }
+    spyOn(mockTarget,'anyOtherMethod').and.returnValue();
+
+    const result = GenericWebpackBuilder.buildWebpackConfig(mockTarget, mockRoot, mockProjectRoot, mockHost, mockBrowserOptions)
+
+    expect(result).toBeUndefined()
+    expect(mockTarget.anyOtherMethod).not.toHaveBeenCalled();
+  });
+
+  it('should not blow up if the target builder is null', () => {
+
+    const result = GenericWebpackBuilder.buildWebpackConfig(undefined, mockRoot, mockProjectRoot, mockHost, mockBrowserOptions)
+
+    expect(result).toBeUndefined()
+  });
+});

--- a/src/generic/generic-webpack-builder.spec.ts
+++ b/src/generic/generic-webpack-builder.spec.ts
@@ -1,45 +1,45 @@
 import {GenericWebpackBuilder} from './generic-webpack-builder';
 import {Path, virtualFs} from '@angular-devkit/core';
 import {Builder} from '@angular-devkit/architect';
-import {BrowserBuilderSchema } from '@angular-devkit/build-angular';
+import {BrowserBuilderSchema} from '@angular-devkit/build-angular';
 import {Stats} from 'fs';
 
 describe('GenericWebpackBuilder test', () => {
 
-  const mockRoot = <Path> 'mockRoot';
-  const mockProjectRoot = <Path> 'mockProjectRoot';
-  const mockHost = <virtualFs.Host<Stats>> <any> 'mockHost';
-  const mockBrowserOptions = <BrowserBuilderSchema> <any> 'mockBrowserOptions';
+	const mockRoot = <Path> 'mockRoot';
+	const mockProjectRoot = <Path> 'mockProjectRoot';
+	const mockHost = <virtualFs.Host<Stats>> <any> 'mockHost';
+	const mockBrowserOptions = <BrowserBuilderSchema> <any> 'mockBrowserOptions';
 
-  it('should invoke the target builder when the target has the buildWebpackConfig method', () => {
-    const mockTarget = <Builder<BrowserBuilderSchema>> <any> {
-      buildWebpackConfig: () => {}
-    }
-    spyOn(mockTarget,'buildWebpackConfig').and.returnValue('mockConfig');
+	it('should invoke the target builder when the target has the buildWebpackConfig method', () => {
+		const mockTarget: { buildWebpackConfig(): any } & Builder<BrowserBuilderSchema> = {
+			buildWebpackConfig: jest.fn(() => 'mockConfig'),
+			run: jest.fn()
+		};
 
-    const result = GenericWebpackBuilder.buildWebpackConfig(mockTarget, mockRoot, mockProjectRoot, mockHost, mockBrowserOptions)
+		const result = GenericWebpackBuilder.buildWebpackConfig(mockTarget, mockRoot, mockProjectRoot, mockHost, mockBrowserOptions);
 
-    expect(result).toBe('mockConfig');
-    expect(mockTarget.buildWebpackConfig).toHaveBeenCalledWith('mockRoot','mockProjectRoot','mockHost','mockBrowserOptions');
+		expect(result).toBe('mockConfig');
+		expect(mockTarget.buildWebpackConfig).toHaveBeenCalledWith('mockRoot', 'mockProjectRoot', 'mockHost', 'mockBrowserOptions');
 
-  });
+	});
 
-  it('should not invoke the target builder when the target does not have the buildWebpackConfig method', () => {
-    const mockTarget = <Builder<BrowserBuilderSchema>> <any> {
-      anyOtherMethod: () => {}
-    }
-    spyOn(mockTarget,'anyOtherMethod').and.returnValue();
+	it('should not invoke the target builder when the target does not have the buildWebpackConfig method', () => {
+		const mockTarget: { anyOtherMethod(): any } & Builder<BrowserBuilderSchema> = {
+			anyOtherMethod: jest.fn(),
+			run: jest.fn()
+		};
 
-    const result = GenericWebpackBuilder.buildWebpackConfig(mockTarget, mockRoot, mockProjectRoot, mockHost, mockBrowserOptions)
+		const result = GenericWebpackBuilder.buildWebpackConfig(mockTarget, mockRoot, mockProjectRoot, mockHost, mockBrowserOptions);
 
-    expect(result).toBeUndefined()
-    expect(mockTarget.anyOtherMethod).not.toHaveBeenCalled();
-  });
+		expect(result).toBeUndefined();
+		expect(mockTarget.anyOtherMethod).not.toHaveBeenCalled();
+	});
 
-  it('should not blow up if the target builder is null', () => {
+	it('should not blow up if the target builder is null', () => {
 
-    const result = GenericWebpackBuilder.buildWebpackConfig(undefined, mockRoot, mockProjectRoot, mockHost, mockBrowserOptions)
+		const result = GenericWebpackBuilder.buildWebpackConfig(undefined, mockRoot, mockProjectRoot, mockHost, mockBrowserOptions);
 
-    expect(result).toBeUndefined()
-  });
+		expect(result).toBeUndefined()
+	});
 });

--- a/src/generic/generic-webpack-builder.ts
+++ b/src/generic/generic-webpack-builder.ts
@@ -3,6 +3,7 @@ import {Path, virtualFs} from '@angular-devkit/core';
 import {Builder} from '@angular-devkit/architect';
 import {BrowserBuilderSchema } from '@angular-devkit/build-angular';
 import {Stats} from 'fs';
+import {Configuration} from "webpack";
 
 export class GenericWebpackBuilder {
 
@@ -11,12 +12,12 @@ export class GenericWebpackBuilder {
     root: Path,
     projectRoot: Path,
     host: virtualFs.Host<Stats>,
-    browserOptions: BrowserBuilderSchema,
-  ) {
+    browserOptions: any,
+  ): Configuration | undefined {
 
     // If our target builder has a webpack config method lets use it. Otherwise we
     // will fall to the default config
-    if (targetBuilder && targetBuilder['buildWebpackConfig'] instanceof Function) {
+    if (targetBuilder && typeof targetBuilder['buildWebpackConfig'] === 'function') {
       return targetBuilder['buildWebpackConfig'](
         root, projectRoot, host, browserOptions
       );

--- a/src/generic/generic-webpack-builder.ts
+++ b/src/generic/generic-webpack-builder.ts
@@ -1,0 +1,27 @@
+
+import {Path, virtualFs} from '@angular-devkit/core';
+import {Builder} from '@angular-devkit/architect';
+import {BrowserBuilderSchema } from '@angular-devkit/build-angular';
+import {Stats} from 'fs';
+
+export class GenericWebpackBuilder {
+
+  static buildWebpackConfig(
+    targetBuilder: Builder<BrowserBuilderSchema> | undefined,
+    root: Path,
+    projectRoot: Path,
+    host: virtualFs.Host<Stats>,
+    browserOptions: BrowserBuilderSchema,
+  ) {
+
+    // If our target builder has a webpack config method lets use it. Otherwise we
+    // will fall to the default config
+    if (targetBuilder && targetBuilder['buildWebpackConfig'] instanceof Function) {
+      return targetBuilder['buildWebpackConfig'](
+        root, projectRoot, host, browserOptions
+      );
+    }
+
+    return;
+  }
+}


### PR DESCRIPTION

This PR is based upon the feedback on https://github.com/meltedspark/angular-cli-builders/pull/6. It creates a new generic dev server where if the build target is a browserBuilder then it uses that builder's public buildWebpackConfig() method to generate the webpack config.